### PR TITLE
Fix daily plan day window boundaries

### DIFF
--- a/trips/shared/types.js
+++ b/trips/shared/types.js
@@ -125,12 +125,14 @@ export function buildInitialDailyPlan({ dateRange, transport, stays }) {
 
     if (i === 0) {
       const startTime = maxTime(readyAt, defaultStart);
+      const endTime = maxTime(defaultEnd, startTime);
       anchor = { type: 'lodging', place: lodging, ready_at: startTime };
-      dayWindow = { start: startTime, end: defaultEnd };
+      dayWindow = { start: startTime, end: endTime };
       blocks.push({ type: 'BUFFER', reason: 'arrival', minutes: inboundBufferByMode(inMode) });
       blocks.push({ type: 'CHECKIN', place: lodging, time: checkIn });
     } else if (i === dates.length - 1) {
-      dayWindow = { start: defaultStart, end: minTime(defaultEnd, targetArriveAtHub) };
+      const endTime = maxTime(defaultStart, minTime(defaultEnd, targetArriveAtHub));
+      dayWindow = { start: defaultStart, end: endTime };
       anchor = { type: 'lodging', place: lodging, ready_at: defaultStart };
       blocks.push({ type: 'CHECKOUT', place: lodging, time: checkOut });
       blocks.push({ type: 'BUFFER', reason: 'security', minutes: mustArriveMin });


### PR DESCRIPTION
### Motivation

- Prevent invalid/negative day windows in generated daily plans when arrivals or departures fall outside the default hours. 
- Avoid UI issues (e.g. freezing when opening the last day) caused by a day window end time being earlier than its start time. 

### Description

- Clamp the first day's window end to never be before its start by setting `endTime = max(defaultEnd, startTime)` and using that for the day window. 
- Clamp the last day's window end so it is not earlier than the start with `endTime = maxTime(defaultStart, minTime(defaultEnd, targetArriveAtHub))`. 
- The changes were made in `trips/shared/types.js` inside `buildInitialDailyPlan` to ensure `dayWindow.end >= dayWindow.start` for edge cases. 

### Testing

- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6964a5fd738c8330b24e4d1944398429)